### PR TITLE
Fix team-awareness when instantiating

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -5,7 +5,7 @@ local argocd = import 'lib/argocd.libjsonnet';
 
 local instance = inv.parameters._instance;
 
-local app = argocd.App(instance, params.namespace.name);
+local app = argocd.App(instance, params.namespace.name, base='loki');
 local appPath =
   local project = std.get(std.get(app, 'spec', {}), 'project', 'syn');
   if project == 'syn' then 'apps' else 'apps-%s' % project;


### PR DESCRIPTION
This PR adds the `base='loki'` parameter to the ArgoCD app to fix team-aware instances.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
